### PR TITLE
seconds to reset, trend/tweet changes

### DIFF
--- a/run_luigi.py
+++ b/run_luigi.py
@@ -50,17 +50,17 @@ vt_logging.basicConfig(
 locations = [
     'usa-nyc',
     'usa-lax',
-    # 'usa-chi',
-    # 'usa-dal',
-    # 'usa-hou',
-    # 'usa-wdc',
-    # 'usa-mia',
-    # 'usa-phi',
-    # 'usa-atl',
-    # 'usa-bos',
-    # 'usa-sfo',
-    # 'usa-det',
-    # 'usa-sea',
+    'usa-chi',
+    'usa-dal',
+    'usa-hou',
+    'usa-wdc',
+    'usa-mia',
+    'usa-phi',
+    'usa-atl',
+    'usa-bos',
+    'usa-sfo',
+    'usa-det',
+    'usa-sea',
 ]
 
 
@@ -184,7 +184,7 @@ class StoreTrimTrendsData(luigi.Task):
         data = self.requires().output().read()
 
         # manipulate data in some way
-        data['trends'] = data['trends'][:10]
+        data['trends'] = data['trends'][:7]
         trend_lst = [d['name'] for d in data['trends']]
 
         trends_out = generate_unique_trends(data)

--- a/utils/get_images.py
+++ b/utils/get_images.py
@@ -32,7 +32,7 @@ def image_parser(trends):
     :return list of tweets with images:
     """
 
-    MAX_TWEETS = 25
+    MAX_TWEETS = 35
 
     logger.info(f'Trends being queried: {trends}')
 

--- a/utils/get_rate_limit_status.py
+++ b/utils/get_rate_limit_status.py
@@ -1,6 +1,8 @@
 import os
+import time
 import tweepy
 
+from datetime import datetime
 from dotenv import load_dotenv
 from utils.constants import ENV_PATH
 
@@ -18,3 +20,12 @@ api = tweepy.API(auth)
 
 print(api.rate_limit_status()['resources']['search']['/search/tweets'])
 print(api.rate_limit_status()['resources']['trends']['/trends/place'])
+
+epoch = api.rate_limit_status()['resources']['search']['/search/tweets'].get('reset')
+epoch_str = time.strftime("%a, %d %b %Y %H:%M:%S %Z", time.localtime(epoch))
+epoch_dt = datetime.strptime(epoch_str, '%a, %d %b %Y %H:%M:%S %Z')
+time_to_reset = epoch_dt - datetime.now()
+seconds = time_to_reset.seconds
+mintues = (seconds % 3600) // 60
+seconds = (seconds % 60)
+print(f'Requests reset in: {mintues} min {seconds} sec')


### PR DESCRIPTION
In 5cce9b3:

**NEW**
-Added seconds to reset for tweepy credentials

**MODIFICATIONS**
-TrimTrend number to 7
-Tweet number to 35 per trend